### PR TITLE
Add #29 handling of filewriting

### DIFF
--- a/src/main/java/ci/App.java
+++ b/src/main/java/ci/App.java
@@ -7,23 +7,6 @@ import org.json.simple.JSONObject;
 
 /** A class for the App. */
 public class App {
-
-    /**
-     * Placeholder function for writing json to file.
-     *
-     * @param jsonObj the json object
-     */
-    public static void writeToFile(File file, JSONObject jsonObj) {
-        try {
-            FileWriter fileWriter = new FileWriter(file);
-            fileWriter.write(jsonObj.toJSONString());
-            fileWriter.close();
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
     /**
      * The main class of the app.
      *
@@ -34,14 +17,13 @@ public class App {
         String dirWithBuild = args[0];
 
         MavenHandler mavenHandler = MavenHandler.getInstance(dirWithBuild);
-        System.out.println("Result of compilation: " + mavenHandler.compileProgram());
-        System.out.println(" " + mavenHandler.getCompileLog());
-        System.out.println("Result of tests: " + mavenHandler.runTests());
-        System.out.println(" " + mavenHandler.getTestLog());
+        String compileStatus = mavenHandler.compileProgram() ? "success" : "failure";
+        String testStatus = mavenHandler.runTests() ? "success" : "failure";
 
-        //        File file = new File(".\\exampleOutput.json");
-        //        JSONObject jsonObject = new JSONObject();
-        //        jsonObject.put("compile", "true");
-        //        writeToFile(file, jsonObject);
+        CIResultWriter ciResultWriter = new CIResultWriter();
+        ciResultWriter.addResult("compile", compileStatus, mavenHandler.getCompileLog());
+        ciResultWriter.addResult("test", testStatus, mavenHandler.getTestLog());
+        ciResultWriter.uploadFile();
+
     }
 }

--- a/src/main/java/ci/App.java
+++ b/src/main/java/ci/App.java
@@ -1,9 +1,6 @@
 package ci;
 
-import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import org.json.simple.JSONObject;
 
 /** A class for the App. */
 public class App {
@@ -24,6 +21,5 @@ public class App {
         ciResultWriter.addResult("compile", compileStatus, mavenHandler.getCompileLog());
         ciResultWriter.addResult("test", testStatus, mavenHandler.getTestLog());
         ciResultWriter.uploadFile();
-
     }
 }

--- a/src/main/java/ci/CIResultWriter.java
+++ b/src/main/java/ci/CIResultWriter.java
@@ -1,0 +1,60 @@
+package ci;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import org.json.simple.JSONObject;
+
+/** Class to write the continuous integration result. */
+public class CIResultWriter {
+  private JSONObject jsonObject;
+  private FileWriter fileWriter;
+
+  /** Constructor that will write to a file in a certain path. */
+  public CIResultWriter(final String path, final String filename) {
+    File file = new File(path + filename);
+    jsonObject = new JSONObject();
+    try {
+      fileWriter = new FileWriter(file);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  /** Default constructor puts the output as output/output.json. */
+  public CIResultWriter() {
+   this("output\\", "output.json");
+  }
+
+  /**
+   * Method that adds result to the json object, containing name, status and logs.
+   *
+   * @param featureName name of the CI feature
+   * @param status status of the CI feature
+   * @param logs logs of the CI feature
+   */
+  public void addResult(final String featureName, final String status, final String logs) {
+    JSONObject result = new JSONObject();
+
+    result.put("status", status);
+    result.put("logs", logs);
+
+    jsonObject.put(featureName, result);
+  }
+
+  /**
+   * Method that uploads the json content to the file.
+   *
+   * @return if the upload was successful
+   */
+  public boolean uploadFile() {
+    try {
+      fileWriter.write(jsonObject.toJSONString());
+      fileWriter.close();
+      return true;
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return false;
+  }
+}

--- a/src/main/java/ci/CIResultWriter.java
+++ b/src/main/java/ci/CIResultWriter.java
@@ -7,54 +7,54 @@ import org.json.simple.JSONObject;
 
 /** Class to write the continuous integration result. */
 public class CIResultWriter {
-  private JSONObject jsonObject;
-  private FileWriter fileWriter;
+    private JSONObject jsonObject;
+    private FileWriter fileWriter;
 
-  /** Constructor that will write to a file in a certain path. */
-  public CIResultWriter(final String path, final String filename) {
-    File file = new File(path + filename);
-    jsonObject = new JSONObject();
-    try {
-      fileWriter = new FileWriter(file);
-    } catch (IOException e) {
-      e.printStackTrace();
+    /** Constructor that will write to a file in a certain path. */
+    public CIResultWriter(final String path, final String filename) {
+        File file = new File(path + filename);
+        jsonObject = new JSONObject();
+        try {
+            fileWriter = new FileWriter(file);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
-  }
 
-  /** Default constructor puts the output as output/output.json. */
-  public CIResultWriter() {
-   this("output\\", "output.json");
-  }
-
-  /**
-   * Method that adds result to the json object, containing name, status and logs.
-   *
-   * @param featureName name of the CI feature
-   * @param status status of the CI feature
-   * @param logs logs of the CI feature
-   */
-  public void addResult(final String featureName, final String status, final String logs) {
-    JSONObject result = new JSONObject();
-
-    result.put("status", status);
-    result.put("logs", logs);
-
-    jsonObject.put(featureName, result);
-  }
-
-  /**
-   * Method that uploads the json content to the file.
-   *
-   * @return if the upload was successful
-   */
-  public boolean uploadFile() {
-    try {
-      fileWriter.write(jsonObject.toJSONString());
-      fileWriter.close();
-      return true;
-    } catch (IOException e) {
-      e.printStackTrace();
+    /** Default constructor puts the output as output/output.json. */
+    public CIResultWriter() {
+        this("output\\", "output.json");
     }
-    return false;
-  }
+
+    /**
+     * Method that adds result to the json object, containing name, status and logs.
+     *
+     * @param featureName name of the CI feature
+     * @param status status of the CI feature
+     * @param logs logs of the CI feature
+     */
+    public void addResult(final String featureName, final String status, final String logs) {
+        JSONObject result = new JSONObject();
+
+        result.put("status", status);
+        result.put("logs", logs);
+
+        jsonObject.put(featureName, result);
+    }
+
+    /**
+     * Method that uploads the json content to the file.
+     *
+     * @return if the upload was successful
+     */
+    public boolean uploadFile() {
+        try {
+            fileWriter.write(jsonObject.toJSONString());
+            fileWriter.close();
+            return true;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
Add `CIResultWriter` that handles the writing of the CI results to a JSON-file

Includes:
- Refactoring of `FileWriter` to the class
- Addition of conversion from CI results to JSON-objects
- Addition of filewriting tof JSON-objects o a JSON-file

Closes #29 